### PR TITLE
Tests for bugs in MonadError instances

### DIFF
--- a/src/Refinery/Tactic/Internal.hs
+++ b/src/Refinery/Tactic/Internal.hs
@@ -156,7 +156,7 @@ instance MonadIO m => MonadIO (RuleT jdg ext err s m) where
 
 instance Monad m => MonadError err (RuleT jdg ext err s m) where
   throwError = coerce . Failure
-  catchError r h = coerce $ flip catchError h $ coerce r
+  catchError = error "it's bottom, you fool"
 
 class (Monad m) => MonadRule jdg ext m | m -> jdg, m -> ext where
   -- | Create a subgoal, and return the resulting extract.

--- a/test/Checkers.hs
+++ b/test/Checkers.hs
@@ -5,8 +5,10 @@
 module Checkers where
 
 import Control.Monad.State.Class
+import Control.Monad.Error.Class
 import Test.QuickCheck hiding (Failure)
 import Test.QuickCheck.Checkers
+import Control.Applicative
 
 monadState
     :: forall m s a b
@@ -38,4 +40,76 @@ monadState _ =
       )
     ]
   )
+
+monadError
+    :: forall m e a
+     . ( MonadError e m
+       , EqProp (m a)
+       , Show (m a)
+       , Show (a)
+       , Show e
+       , Function e
+       , CoArbitrary e
+       , Arbitrary e
+       , Arbitrary a
+       , Arbitrary (m a)
+       )
+    => m a
+    -> TestBatch
+monadError _ =
+  ( "MonadError laws"
+  , [ ("catchError (pure a) (const h)", property $ do
+        a  <- arbitrary @a
+        eh <- arbitrary @(m a)
+        pure $
+          counterexample (show a) $
+          counterexample (show eh) $
+            (catchError (pure a) (const eh)) =-= pure a
+      )
+    , ("catchError (throwError e) h", property $ do
+        e <- arbitrary @e
+        h <- arbitrary @(Fun e (m a))
+        pure $
+          counterexample (show e) $
+          counterexample (show h) $
+            (catchError (throwError e) (applyFun h)) =-= applyFun h e
+      )
+    , ("catchError (catchError a h1) h2", property $ do
+        a <- arbitrary @(m a)
+        h1 <- arbitrary @(Fun e (m a))
+        h2 <- arbitrary @(Fun e (m a))
+        pure $
+          counterexample (show a) $
+          counterexample (show h1) $
+          counterexample (show h2) $
+            catchError (catchError a (applyFun h1)) (applyFun h2) =-=
+              (catchError a (\e -> catchError (applyFun h1 e) (applyFun h2)))
+      )
+    ]
+  )
+
+
+catchAlt
+    :: forall m a e
+     . ( MonadError e m
+       , Alternative m
+       , EqProp (m a)
+       , Show e
+       , Show (m a)
+       , Function e
+       , CoArbitrary e
+       , Arbitrary e
+       , Arbitrary (m a)
+       )
+    => m a
+    -> Property
+catchAlt _ = property $ do
+  ma <- arbitrary @(m a)
+  e <- arbitrary @e
+  h <- arbitrary @(Fun e (m a))
+  pure $
+    counterexample (show ma) $
+    counterexample (show e) $
+    counterexample (show h) $
+      catchError (ma <|> throwError e) (applyFun h) =-= applyFun h e
 


### PR DESCRIPTION
Ran into weird behavior in HLS. Added some tests here to see what's up, and found a few bugs. 

This PR makes #5 an `error` instead of a bottom, adds MonadError tests (which all pass), but which don't succeed wrt. `Alternative`, namely that

```haskell
catchError (a <|> throw e) h = h e
```